### PR TITLE
商品詳細表示機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,7 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+group :development do
+  gem 'rubocop', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     method_source (1.1.0)
     mini_magick (4.13.1)
     mini_mime (1.1.5)
-    minitest (5.24.0)
+    minitest (5.24.1)
     msgpack (1.7.2)
     mysql2 (0.5.6)
     net-imap (0.4.14)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,14 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
     # [item1, item2, ...]
     # []
+  end
+
+  def show
   end
 
   def new
@@ -22,7 +26,10 @@ class ItemsController < ApplicationController
   end
     
   private
-  
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
   def item_params
     params.require(:item).permit(:product_name, :description, :category_id, :condition_id, :shipping_fee_burden_id, :prefecture_id, :shipping_day_id, :price, :item_image)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
-  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_item, only: [:show]
 
   def index
     @items = Item.order(created_at: :desc)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,74 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+     <%= link_to item_path(@item) do %>
+     <%= image_tag @item.item_image, class: "item-box-img" %>
+     <% end %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.sold? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee_burden.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+<% if user_signed_in? %>
+  <% if @item.user == current_user && !@item.sold? %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除",  item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
 
-
+ <% elsif @item.user != current_user && !@item.sold? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+  <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+<% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description  %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,15 +7,15 @@
       <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
-     <%= link_to item_path(@item) do %>
+    
      <%= image_tag @item.item_image, class: "item-box-img" %>
-     <% end %>
+    
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <% if @item.sold? %>
+      <%# if @item.sold? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <% end %>
+      <%# end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -27,22 +27,19 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 <% if user_signed_in? %>
-  <% if @item.user == current_user && !@item.sold? %>
+  <% if @item.user == current_user # && !@item.sold?%> 
 
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除",  item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
 
- <% elsif @item.user != current_user && !@item.sold? %>
+ <% elsif @item.user != current_user# && !@item.sold? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
   <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 <% end %>
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description  %></span>
@@ -110,9 +107,8 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,7 +34,7 @@
     <p class="or-text">or</p>
     <%= link_to "削除",  item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
 
- <% elsif @item.user != current_user# && !@item.sold? %>
+ <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,9 +10,9 @@ module Furima40958
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    # config.i18n.default_locale = :ja
+    # config.time_zone = 'Tokyo'
     config.active_storage.variant_processor = :mini_magick
-    config.i18n.default_locale = :ja
-    config.time_zone = 'Tokyo'
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,7 @@ Rails.application.routes.draw do
 devise_for :users
 
 # 商品関連のルーティング
-resources :items do
-  # 追加のアクションやリソースを設定する場合はここに記述
-end
+resources :items 
 
 # ユーザー情報編集のルーティング
 resources :users, only: [:edit, :update]


### PR DESCRIPTION
What
商品詳細ページにて条件分岐

Why
ログイン、ログアウト時の表示切り替え
売却前後での表示の切り替え
のため

画像提出
ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画 – 
https://gyazo.com/288b040905b9907712484a43ab23d694

 ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画 – 
https://gyazo.com/99b5bab61222915922e7966f9c3a1b26

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合） -

→現段階で商品購入機能の実装をできませんでしたので、確認できませんでした。

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/e8d8c79c8e7bc212d53e03753e9b861c

ご確認くださいますよう、お願いいたします。