### PR TITLE
削除完了時の動作

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :correct_user, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :correct_user, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -40,7 +40,15 @@ class ItemsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
-end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path, notice: '商品を削除しました。'
+    else
+      redirect_to item_path(@item), alert: '商品の削除に失敗しました。'
+    end
+  end
+
 
   private
 
@@ -58,4 +66,4 @@ end
   def item_params
     params.require(:item).permit(:product_name, :description, :category_id, :condition_id, :shipping_fee_burden_id, :prefecture_id, :shipping_day_id, :price, :item_image)
   end
-
+end


### PR DESCRIPTION
What
商品の情報を削除する機能の実装

Why
削除完了後の動作を実装するため
・ログイン状態のみ
・完了後トップページ（root_path）へ遷移

画像提出
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/ca6af453955415edb472faf2e6edd1de